### PR TITLE
feat: Migrate from deps.edn to Leiningen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Leiningen
+/target
+/pom.xml
+/project.clj.swp
+.lein-deps-sum
+.lein-failures
+.lein-plugins/
+.lein-repl-history
+.lein-resolve-log
+.lein-classpath
+
+# Clojure
+/.nrepl-port
+/classes/
+
+# Editor
+.idea/
+*.iml
+.ensime_cache/
+.eunit/
+.dir-locals.el
+*~
+*#
+.#*

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,0 @@
-{:paths ["src"]
- :deps  {org.clojure/clojure {:mvn/version "1.11.1"}
-         ring/ring-core {:mvn/version "1.9.5"}
-         ring/ring-jetty-adapter {:mvn/version "1.9.5"}
-         metosin/reitit {:mvn/version "0.5.18"}
-         metosin/muuntaja {:mvn/version "0.6.8"}}
- :aliases
- {:run {:main-opts ["-m" "juridico.api.core"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,12 @@
+(defproject juridico-api "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [ring/ring-core "1.9.5"]
+                 [ring/ring-jetty-adapter "1.9.5"]
+                 [metosin/reitit "0.5.18"]
+                 [metosin/muuntaja "0.6.8"]]
+  :main juridico.api.core
+  :repl-options {:init-ns juridico.api.core})


### PR DESCRIPTION
This migrates the project from using `deps.edn` to Leiningen.

A `project.clj` file has been created to define the project's dependencies and configuration. The dependencies from `deps.edn` have been translated to the Leiningen format.

The old `deps.edn` file has been removed to avoid confusion.

A `.gitignore` file has been added with standard entries for Leiningen and Clojure projects.