### PR TITLE
feat: Dockerize the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Etapa 1: Build - Use a imagem oficial do Leiningen para compilar o projeto
+FROM clojure:lein-2.9.1 as builder
+
+# Defina o diretório de trabalho dentro do contêiner
+WORKDIR /app
+
+# Copie os arquivos de definição do projeto primeiro para aproveitar o cache do Docker
+COPY project.clj .
+# Baixe as dependências. Isso será cacheado se o project.clj não mudar.
+RUN lein deps
+
+# Copie o código-fonte da aplicação
+COPY src ./src
+
+# Compile a aplicação em um uberjar (JAR auto-suficiente)
+RUN lein uberjar
+
+# Etapa 2: Execução - Use uma imagem leve com apenas o Java Runtime Environment (JRE)
+FROM openjdk:11-jre-slim
+
+# Defina o diretório de trabalho
+WORKDIR /app
+
+# Copie o uberjar da etapa de build para a imagem final
+COPY --from=builder /app/target/juridico-api-0.1.0-SNAPSHOT-standalone.jar ./app.jar
+
+# Defina as variáveis de ambiente
+ENV PORT="3000"
+
+# Exponha a porta que o servidor web irá usar
+EXPOSE 3000
+
+# Comando para executar a aplicação quando o contêiner iniciar
+CMD ["java", "-jar", "app.jar"]

--- a/src/juridico/api/core.clj
+++ b/src/juridico/api/core.clj
@@ -41,5 +41,6 @@
 ;; --- Ponto de Entrada ---
 ;; A função -main é o ponto de entrada para rodar a aplicação.
 (defn -main []
-  (println "Iniciando servidor na porta 3000...")
-  (jetty/run-jetty app {:port 3000 :join? false}))
+  (let [port (Integer/parseInt (or (System/getenv "PORT") "3000"))]
+    (println "Iniciando servidor na porta" port "...")
+    (jetty/run-jetty app {:port port :join? false})))


### PR DESCRIPTION
Adds a multi-stage Dockerfile to build and run the application in a container.

- The build stage uses a Leiningen image to compile an uberjar.
- The final stage uses a slim JRE image for a smaller footprint.
- The application is modified to read the port from the `PORT` environment variable, with a default of 3000.