### PR TITLE
feat: Add comprehensive project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Este projeto é a estrutura inicial para uma API REST de um ERP jurídico, const
 
 A arquitetura foi desenhada para ser modular, testável e escalável.
 
-1.  **Padrão Repository com `protocol`**: Toda a interação com dados é mediada por um "contrato" definido em `meuerp.db.protocols`. Isso desacopla a lógica de negócio dos detalhes de implementação do banco de dados. Para trocar o banco de dados, basta criar um novo `defrecord` que implemente o mesmo protocolo.
+1.  **Padrão Repository com `protocol`**: Toda a interação com dados é mediada por um "contrato" definido em `juridico.api.db.protocols`. Isso desacopla a lógica de negócio dos detalhes de implementação do banco de dados. Para trocar o banco de dados, basta criar um novo `defrecord` que implemente o mesmo protocolo.
 
-2.  **Banco de Dados Mock com `atom`**: Para desenvolvimento e testes, um `atom` global em `meuerp.db.mock` simula o banco de dados. Ele é pré-populado com dados para dois tenants (`tenant-1` e `tenant-2`) para permitir a verificação do isolamento de dados.
+2.  **Banco de Dados Mock com `atom`**: Para desenvolvimento e testes, um `atom` global em `juridico.api.db.mock` simula o banco de dados. Ele é pré-populado com dados para dois tenants (`tenant-1` e `tenant-2`) para permitir a verificação do isolamento de dados.
 
-3.  **Injeção de Dependência via Middleware**: Um middleware customizado (`meuerp.middleware/wrap-db-repo`) intercepta cada requisição, lê o cabeçalho `X-Tenant-ID` para identificar o tenant, e instancia o repositório correto. Este repositório, já configurado para o tenant específico, é então "injetado" na requisição, ficando disponível para os handlers. Isso mantém os handlers limpos e sem conhecimento direto sobre o multi-tenancy.
+3.  **Injeção de Dependência via Middleware**: Middlewares customizados (`juridico.api.middleware`) interceptam cada requisição, identificam o contexto (público ou de *tenant*) e instanciam o repositório correto. Este repositório, já configurado para o escopo necessário, é então "injetado" na requisição, ficando disponível para os handlers.
 
 4.  **Roteamento com Reitit**: As rotas da API, a negociação de conteúdo (JSON) e a aplicação de middlewares são gerenciadas pela biblioteca Reitit, que oferece uma forma declarativa e eficiente de definir os endpoints.
 
@@ -20,58 +20,82 @@ O projeto está organizado da seguinte forma para promover a separação de resp
 
 ```
 /src
-└── /meuerp
-    ├── core.clj          # Ponto de entrada: define rotas, aplica middlewares e inicia o servidor.
-    ├── db
-    │   ├── protocols.clj # Define o "contrato" (protocol) da camada de dados.
-    │   └── mock.clj      # Implementação do banco de dados mock com `atom` e o `defrecord` do repositório.
-    ├── middleware.clj    # Middleware customizado para autenticação simulada e injeção de dependência.
-    └── handlers.clj      # Lógica dos handlers da API, que orquestram as requisições.
+└── /juridico
+    └── /api
+        ├── core.clj          # Ponto de entrada: define rotas, aplica middlewares e inicia o servidor.
+        ├── db
+        │   ├── protocols.clj # Define o "contrato" (protocol) da camada de dados.
+        │   └── mock.clj      # Implementação do banco de dados mock com `atom` e o `defrecord` do repositório.
+        ├── middleware.clj    # Middlewares customizados para injeção de dependência e contexto.
+        ├── handlers.clj      # Lógica dos handlers da API, que orquestram as requisições.
+        └── specs.clj         # Definições de `clojure.spec` para validação de dados.
 ```
 
 ## Como Executar o Projeto
 
 **Pré-requisitos:**
 *   [Java Development Kit (JDK)](https://www.oracle.com/java/technologies/downloads/)
-*   [Ferramentas de Linha de Comando do Clojure](https://clojure.org/guides/getting_started)
+*   [Leiningen](https://leiningen.org/)
 
 Com os pré-requisitos instalados, inicie o servidor com o seguinte comando a partir da raiz do projeto:
 
 ```bash
-clj -M:run
+lein run
 ```
 
-O servidor será iniciado na porta `3000`.
+O servidor será iniciado na porta `3000` por padrão, ou na porta definida pela variável de ambiente `PORT`.
 
 ## Como Testar a API
 
-Use `curl` ou uma ferramenta de sua preferência para fazer requisições à API. O cabeçalho `X-Tenant-ID` é **obrigatório** para todas as requisições.
+Use `curl` ou uma ferramenta de sua preferência para fazer requisições à API.
 
-### 1. Listar processos (Tenant 1)
+### Testes de Provisionamento e Autenticação
+
+**1. Provisionar um novo Tenant**
+*Cria um novo tenant e seu usuário admin. Retorna o subdomínio e a senha temporária.*
+```bash
+curl -i -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"company_name": "Nova Advocacia", "email": "admin@nova.com"}' \
+  http://localhost:3000/admin/provision-tenant
+```
+
+**2. Autenticar (Login)**
+*Usa os dados do passo anterior para simular um login. Retorna um token JWT simulado.*
+```bash
+curl -i -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"subdomain": "nova-advocacia", "email": "admin@nova.com", "password": "SENHA_TEMPORARIA_RECEBIDA"}' \
+  http://localhost:3000/auth/login
+```
+
+### Testes de API Protegida (Exige `X-Tenant-ID`)
+
+**3. Listar processos (Tenant 1)**
 *Deve retornar 2 processos.*
 ```bash
 curl -i -H "X-Tenant-ID: tenant-1" http://localhost:3000/api/processos
 ```
 
-### 2. Listar processos (Tenant 2)
+**4. Listar processos (Tenant 2)**
 *Deve retornar 1 processo.*
 ```bash
 curl -i -H "X-Tenant-ID: tenant-2" http://localhost:3000/api/processos
 ```
 
-### 3. Obter processo por ID (Sucesso)
+**5. Obter processo por ID (Sucesso)**
 *Busca um processo que pertence ao Tenant 1.*
 ```bash
 curl -i -H "X-Tenant-ID: tenant-1" http://localhost:3000/api/processos/proc-111
 ```
 
-### 4. Obter processo por ID (Falha - Isolamento de Tenant)
-*Tenta buscar um processo do Tenant 2 usando as credenciais do Tenant 1. Deve retornar 404.*
+**6. Obter processo por ID (Falha - Isolamento de Tenant)**
+*Tenta buscar um processo do Tenant 2 usando as credenciais do Tenant 1. Deve retornar 404 Not Found.*
 ```bash
 curl -i -H "X-Tenant-ID: tenant-1" http://localhost:3000/api/processos/proc-333
 ```
 
-### 5. Criar um novo processo (Tenant 2)
+**7. Criar um novo processo (Tenant 2)**
 *Cria um novo processo para o Tenant 2.*
 ```bash
 curl -i -X POST \
@@ -81,13 +105,7 @@ curl -i -X POST \
   http://localhost:3000/api/processos
 ```
 
-### 6. Verificar criação
-*Lista os processos do Tenant 2 novamente. Deve agora retornar 2 processos.*
-```bash
-curl -i -H "X-Tenant-ID: tenant-2" http://localhost:3000/api/processos
-```
-
-### 7. Requisição sem Tenant ID
+**8. Requisição sem Tenant ID**
 *Deve retornar um erro 401 Unauthorized.*
 ```bash
 curl -i http://localhost:3000/api/processos

--- a/docs/Dockerfile.md
+++ b/docs/Dockerfile.md
@@ -1,0 +1,38 @@
+# Documentação: `Dockerfile`
+
+## Visão Geral
+
+O `Dockerfile` é um script que contém uma série de instruções para construir uma **imagem de contêiner** para a aplicação. Uma imagem de contêiner é um pacote leve, autônomo e executável que inclui tudo o que é necessário para rodar uma aplicação: o código, o ambiente de execução (neste caso, o Java Runtime Environment), bibliotecas, variáveis de ambiente e arquivos de configuração.
+
+O uso de contêineres, gerenciados por uma ferramenta como o Docker, garante que a aplicação rode da mesma forma em qualquer ambiente, seja na máquina de um desenvolvedor, em um servidor de testes ou em produção.
+
+Este `Dockerfile` utiliza uma técnica avançada e recomendada chamada **build multi-stage (múltiplos estágios)**.
+
+---
+
+## O Build Multi-Stage
+
+A principal vantagem de um build multi-stage é a criação de uma imagem final **pequena e segura**. A ideia é usar uma imagem grande e cheia de ferramentas para *compilar* a aplicação, e depois copiar *apenas o artefato compilado* para uma imagem final "limpa" e minimalista, que contém apenas o necessário para *executar* a aplicação.
+
+### Etapa 1: O Ambiente de Build (`as builder`)
+
+Esta primeira etapa é responsável por compilar o código-fonte Clojure em um arquivo `.jar` executável.
+
+-   `FROM clojure:lein-2.9.1 as builder`: Começamos com uma imagem base oficial que já vem com o Clojure e a ferramenta de build `Leiningen` instalados. Esta imagem é relativamente grande, pois contém todo o ambiente de desenvolvimento.
+-   `WORKDIR /app`: Define o diretório de trabalho padrão dentro do contêiner.
+-   `COPY project.clj .` e `RUN lein deps`: Esta é uma otimização importante. Primeiro, copiamos apenas o `project.clj` e rodamos `lein deps` para baixar as dependências. Como o `project.clj` muda com menos frequência que o código-fonte, o Docker pode usar o cache desta camada, acelerando builds futuros.
+-   `COPY src ./src`: Copia o código-fonte da aplicação para o contêiner.
+-   `RUN lein uberjar`: Executa o comando do Leiningen para compilar todo o código e empacotá-lo, junto com todas as suas dependências, em um único arquivo `.jar` auto-suficiente (o "uberjar").
+
+Ao final desta etapa, temos o arquivo `juridico-api-0.1.0-SNAPSHOT-standalone.jar` dentro do diretório `/app/target/` do contêiner de build.
+
+### Etapa 2: O Ambiente de Execução (Imagem Final)
+
+Esta segunda etapa constrói a imagem final que será distribuída e executada.
+
+-   `FROM openjdk:11-jre-slim`: A imagem final é baseada em uma imagem oficial do OpenJDK que contém **apenas o Java Runtime Environment (JRE)**. Ela não tem o compilador, o Leiningen, nem o código-fonte. Isso a torna muito menor e mais segura (menos superfície de ataque).
+-   `WORKDIR /app`: Define o diretório de trabalho na imagem final.
+-   `COPY --from=builder /app/target/... ./app.jar`: Esta é a instrução chave do multi-stage. Ela copia o `uberjar` gerado na Etapa 1 (`from=builder`) para a imagem final e o renomeia para `app.jar`.
+-   `ENV PORT="3000"`: Define a variável de ambiente `PORT` dentro do contêiner. A aplicação (`core.clj`) lê esta variável para saber em qual porta deve iniciar o servidor.
+-   `EXPOSE 3000`: Informa ao Docker que o contêiner escuta na porta `3000` em tempo de execução. Isso não publica a porta, mas serve como documentação e pode ser usado por outras ferramentas.
+-   `CMD ["java", "-jar", "app.jar"]`: Define o comando padrão que será executado quando um contêiner for iniciado a partir desta imagem. Ele simplesmente executa o `uberjar` da aplicação.

--- a/docs/README-file-doc.md
+++ b/docs/README-file-doc.md
@@ -1,0 +1,45 @@
+# Documentação sobre o arquivo: `README.md`
+
+## Visão Geral
+
+O arquivo `README.md` é, por convenção, o primeiro documento que um desenvolvedor deve ler ao encontrar um novo projeto. Ele serve como um guia rápido e um ponto de partida, fornecendo as informações essenciais para entender, configurar, executar e testar o software.
+
+Um bom `README.md` acelera a integração de novos membros na equipe e facilita o uso do projeto pela comunidade.
+
+---
+
+## Análise do `README.md` do Projeto
+
+O `README.md` deste projeto é bem estruturado e cobre as áreas mais importantes.
+
+### Seções Principais
+
+1.  **Visão Geral da Arquitetura:**
+    -   Descreve os principais pilares do design da aplicação: o Padrão Repository com `protocol`, o uso de um `atom` para o banco de dados mock, a injeção de dependência via middleware e o uso da biblioteca `Reitit` para roteamento. Esta seção dá um excelente resumo conceitual do funcionamento do sistema.
+
+2.  **Estrutura de Arquivos:**
+    -   Apresenta uma árvore de diretórios do código-fonte e descreve a responsabilidade de cada arquivo. Isso ajuda os desenvolvedores a navegar pela base de código.
+
+3.  **Como Executar o Projeto:**
+    -   Lista os pré-requisitos (JDK e Clojure CLI) e fornece o comando para iniciar o servidor.
+
+4.  **Como Testar a API:**
+    -   Fornece uma lista abrangente de exemplos de comandos `curl` para interagir com a API. Esta seção é extremamente útil para testes manuais e para entender o comportamento esperado de cada endpoint, incluindo os testes de segurança para o isolamento de *tenants*.
+
+---
+
+### Pontos de Atenção e Discrepâncias
+
+Durante a análise, foram identificadas algumas inconsistências entre o `README.md` e o estado atual do código-fonte. Isso é comum em projetos que evoluem rapidamente.
+
+1.  **Nomes de Namespace e Caminhos de Arquivo:**
+    -   **Problema:** O `README.md` refere-se a namespaces e caminhos como `meuerp.core`, `meuerp.db.protocols`, etc.
+    -   **Realidade:** A estrutura de arquivos real do projeto usa o namespace `juridico.api` (ex: `src/juridico/api/core.clj`).
+    -   **Ação:** Esta é uma discrepância crítica que deve ser corrigida no `README.md` para evitar confusão.
+
+2.  **Comando de Execução:**
+    -   **Problema:** O `README.md` instrui a usar `clj -M:run`, que é o comando para ferramentas da CLI do Clojure. No entanto, o projeto contém um arquivo `project.clj`, que é o arquivo de configuração do **Leiningen**, outra ferramenta de build. O comando para Leiningen seria `lein run`.
+    -   **Realidade:** A aplicação pode ser compatível com ambas as ferramentas, mas a presença do `project.clj` torna o Leiningen a ferramenta mais provável ou primária.
+    -   **Ação:** O `README.md` poderia ser atualizado para mencionar o Leiningen ou clarificar por que o comando `clj` é preferido.
+
+Estas discrepâncias indicam que o `README.md` precisa ser sincronizado com o código-fonte atual para continuar sendo um guia preciso e confiável.

--- a/docs/gitignore.md
+++ b/docs/gitignore.md
@@ -1,0 +1,42 @@
+# Documentação: `.gitignore`
+
+## Visão Geral
+
+O arquivo `.gitignore` é um arquivo de configuração para o sistema de controle de versão Git. Sua função é instruir o Git a ignorar certos arquivos e diretórios, impedindo que eles sejam acidentalmente adicionados ao histórico de commits do projeto (o repositório).
+
+Isso é fundamental para manter o repositório limpo, focando apenas no código-fonte e nos arquivos essenciais, e excluindo:
+
+-   **Artefatos de Build:** Arquivos gerados automaticamente pelo processo de compilação (ex: classes compiladas, pacotes).
+-   **Dependências:** Bibliotecas de terceiros que são baixadas e gerenciadas pela ferramenta de build.
+-   **Arquivos de Configuração do Editor/IDE:** Configurações específicas do ambiente de desenvolvimento de um programador, que não devem ser compartilhadas.
+-   **Arquivos Temporários e de Cache:** Arquivos criados por ferramentas ou pelo sistema operacional que não têm relevância para o projeto.
+-   **Arquivos de Credenciais:** Arquivos contendo senhas, chaves de API ou outras informações sensíveis.
+
+---
+
+## Detalhamento do Conteúdo
+
+O `.gitignore` deste projeto está dividido em seções lógicas:
+
+### Seção `# Leiningen`
+
+Esta seção lista os arquivos e diretórios gerados pelo **Leiningen**, a ferramenta de automação e gerenciamento de dependências para projetos Clojure.
+
+-   `/target`: O diretório padrão onde o Leiningen coloca todos os artefatos de compilação, como arquivos `.class`, o pacote `.jar` final, etc. Este diretório pode ser completamente recriado a partir do código-fonte, por isso não deve ser versionado.
+-   `/pom.xml`: O Leiningen pode interoperar com o Maven (outra ferramenta de build) e gera este arquivo para compatibilidade.
+-   Arquivos com prefixo `.lein-`: São arquivos de cache, histórico ou estado interno do Leiningen.
+
+### Seção `# Clojure`
+
+-   `/.nrepl-port`: Quando um processo REPL (Read-Eval-Print Loop) do Clojure é iniciado, ele pode criar este arquivo para armazenar o número da porta em que está rodando, permitindo que editores de texto e outras ferramentas se conectem a ele.
+-   `/classes/`: Um diretório que pode ser usado para armazenar arquivos de classe Java compilados, caso o projeto inclua código Java.
+
+### Seção `# Editor`
+
+Esta seção contém padrões para ignorar arquivos de configuração e de estado de editores de código e IDEs (Ambientes de Desenvolvimento Integrado) populares.
+
+-   `.idea/` e `*.iml`: Diretórios e arquivos de configuração específicos do IntelliJ IDEA.
+-   `.ensime_cache/`: Cache do ENSIME, um ambiente de desenvolvimento para Scala e Java em editores como Emacs e Atom.
+-   `*~`, `*#`, `.#*`: Padrões comuns para arquivos de backup e temporários criados por editores como Vim e Emacs.
+
+Manter esses arquivos fora do Git garante que a configuração pessoal de um desenvolvedor não entre em conflito com a de outro.

--- a/docs/project-clj.md
+++ b/docs/project-clj.md
@@ -1,0 +1,50 @@
+# Documentação: `project.clj`
+
+## Visão Geral
+
+O arquivo `project.clj` é o coração de um projeto gerenciado pelo **Leiningen**, a ferramenta de automação de build mais popular para Clojure. Este arquivo declarativo informa ao Leiningen tudo o que ele precisa saber sobre o projeto: seu nome, sua versão, suas dependências, seu ponto de entrada principal e muito mais.
+
+É um arquivo de código Clojure, o que o torna extremamente poderoso e configurável, mas para a maioria dos usos, ele consiste em uma única macro `defproject` com uma série de diretivas (palavras-chave).
+
+---
+
+## Detalhamento das Diretivas
+
+### `(defproject juridico-api "0.1.0-SNAPSHOT" ...)`
+
+Esta é a definição principal do projeto.
+
+-   `juridico-api`: O nome do projeto (group-id e artifact-id no jargão do Maven).
+-   `"0.1.0-SNAPSHOT"`: A versão atual do projeto. A palavra-chave `SNAPSHOT` indica que esta é uma versão de desenvolvimento e não uma release estável.
+
+### `:description "FIXME: write description"`
+
+-   Uma breve descrição do projeto. O valor "FIXME" é um placeholder que deve ser substituído por uma descrição real.
+
+### `:url "http://example.com/FIXME"`
+
+-   A URL do site do projeto ou do repositório de código. Também é um placeholder.
+
+### `:license {...}`
+
+-   Define a licença de software sob a qual o projeto é distribuído.
+
+### `:dependencies [[...]]`
+
+Esta é uma das seções mais importantes. Ela define a lista de todas as bibliotecas de terceiros das quais o projeto depende. O Leiningen lerá esta lista e baixará automaticamente as bibliotecas e suas dependências transitivas dos repositórios públicos (como Clojars e Maven Central) na primeira vez que o projeto for construído.
+
+As dependências deste projeto são:
+
+-   `[org.clojure/clojure "1.11.1"]`: A própria linguagem Clojure.
+-   `[ring/ring-core "1.9.5"]`: A especificação principal do Ring, que fornece a abstração base para aplicações web em Clojure (mapas de requisição e resposta).
+-   `[ring/ring-jetty-adapter "1.9.5"]`: Um "adaptador" que permite que uma aplicação Ring seja executada em um servidor web Jetty.
+-   `[metosin/reitit "0.5.18"]`: Uma biblioteca moderna e performática para roteamento de requisições. É usada em `core.clj` para definir todas as rotas da API.
+-   `[metosin/muuntaja "0.6.8"]`: Uma biblioteca para negociação de formato de conteúdo. Ela é responsável por, por exemplo, converter automaticamente o corpo de uma requisição JSON em um mapa Clojure e vice-versa.
+
+### `:main juridico.api.core`
+
+Esta diretiva informa ao Leiningen qual namespace contém a função `-main`, que é o ponto de entrada da aplicação. Isso é usado quando você executa `lein run` ou quando constrói um `.jar` executável (`uberjar`).
+
+### `:repl-options {:init-ns juridico.api.core}`
+
+-   Configura o comportamento do REPL (Read-Eval-Print Loop). A opção `:init-ns` instrui o Leiningen a carregar e mudar para o namespace `juridico.api.core` assim que o REPL for iniciado com o comando `lein repl`. Isso é uma conveniência para o desenvolvimento interativo.

--- a/docs/src-juridico-api-core-clj.md
+++ b/docs/src-juridico-api-core-clj.md
@@ -1,0 +1,57 @@
+# Documentação: `src/juridico/api/core.clj`
+
+## Visão Geral
+
+Este é o arquivo principal e ponto de entrada (`main`) da aplicação `juridico-api`. Sua responsabilidade central é configurar e iniciar o servidor web, definir todas as rotas da API e conectar os middlewares necessários para o processamento das requisições.
+
+Ele utiliza a biblioteca `reitit` para uma definição de rotas clara e baseada em dados, e o `ring-jetty-adapter` para servir a aplicação.
+
+---
+
+## Detalhamento do Código
+
+### Dependências (Namespaces Requeridos)
+
+O namespace `juridico.api.core` importa várias bibliotecas e módulos internos essenciais:
+
+- `ring.adapter.jetty`: Utilizado para iniciar o servidor web Jetty que hospedará a aplicação.
+- `reitit.ring`: A biblioteca principal para a criação e gerenciamento das rotas da API.
+- `reitit.ring.middleware.muuntaja`: Um middleware que se integra ao `reitit` para automaticamente negociar e transformar formatos de dados (ex: converter request bodies de JSON para mapas Clojure e vice-versa).
+- `muuntaja.core`: A biblioteca de negociação de conteúdo subjacente.
+- `juridico.api.handlers`: Importa as funções que efetivamente lidam com a lógica de cada rota (ex: `provision-tenant-handler`).
+- `juridico.api.middleware`: Importa os middlewares customizados da aplicação, cruciais para a lógica de multi-tenancy.
+
+### Definição das Rotas (`def routes`)
+
+A variável `routes` define a estrutura completa de todas as rotas da API de forma hierárquica. As rotas são divididas em duas seções principais, cada uma com seu próprio middleware de contexto:
+
+1.  **Rotas Públicas (`/admin`, `/auth`)**:
+    - **Middleware:** `mw/wrap-public-db-repo`
+    - **Propósito:** Estas rotas são usadas para operações que não pertencem a um *tenant* específico, como o provisionamento de um novo *tenant* ou a autenticação inicial para obter um token. O middleware `wrap-public-db-repo` fornece um contexto de banco de dados "global" para essas operações.
+    - **Endpoints:**
+        - `POST /admin/provision-tenant`: Provisiona uma nova conta de *tenant*.
+        - `POST /auth/login`: Autentica um usuário.
+
+2.  **Rotas Protegidas (`/api`)**:
+    - **Middleware:** `mw/wrap-tenant-db-repo`
+    - **Propósito:** Estas são as rotas de negócio da aplicação, que manipulam dados pertencentes a um *tenant* específico. O middleware `mw/wrap-tenant-db-repo` é um ponto de segurança crítico: ele exige a presença do header `x-tenant-id` na requisição, validando-o e injetando um contexto de banco de dados que isola todas as operações àquele *tenant*. Se o header estiver ausente ou for inválido, o acesso é bloqueado.
+    - **Endpoints:**
+        - `GET /api/processos`: Lista todos os processos do *tenant*.
+        - `POST /api/processos`: Cria um novo processo para o *tenant*.
+        - `GET /api/processos/{id}`: Obtém um processo específico pelo seu ID, dentro do escopo do *tenant*.
+
+### Handler Principal da Aplicação (`def app`)
+
+A variável `app` constrói o handler principal do Ring, que é a função que processa todas as requisições HTTP recebidas. Ela é composta por:
+
+1.  `ring/router`: Pega a estrutura de `routes` e a transforma em um roteador funcional.
+2.  `{:data {:muuntaja m/instance, :middleware [...]}}`: Configura o roteador. Aqui, ele é instruído a usar o `muuntaja` para processar corpos de requisição e resposta (JSON, etc.) automaticamente.
+3.  `ring/create-default-handler`: Define o que acontece se nenhuma rota corresponder à requisição. Neste caso, retorna uma resposta `404 Not Found`.
+
+### Ponto de Entrada (`defn -main`)
+
+A função `-main` é o ponto de entrada padrão para uma aplicação Clojure. Suas ações são:
+
+1.  Obter a porta do servidor a partir da variável de ambiente `PORT`. Se não estiver definida, usa `3000` como padrão.
+2.  Imprimir uma mensagem no console indicando que o servidor está iniciando.
+3.  Chamar `jetty/run-jetty` para iniciar o servidor web na porta especificada, passando o handler `app` para processar as requisições. A opção `:join? false` permite que o servidor rode em uma thread separada, não bloqueando o processo principal (útil em desenvolvimento).

--- a/docs/src-juridico-api-db-mock-clj.md
+++ b/docs/src-juridico-api-db-mock-clj.md
@@ -1,0 +1,60 @@
+# Documentação: `src/juridico/api/db/mock.clj`
+
+## Visão Geral
+
+Este arquivo contém a implementação **concreta** e **em memória** dos protocolos de persistência (`ProcessosRepository` e `AuthRepository`) definidos em `protocols.clj`. Ele funciona como uma camada de banco de dados "fake" ou "mock", permitindo que a aplicação seja desenvolvida e testada sem a necessidade de um banco de dados real como o PostgreSQL.
+
+Toda a lógica de manipulação de dados para a Prova de Conceito (PoC) reside aqui.
+
+---
+
+## Detalhamento do Código
+
+### O Banco de Dados em Memória (`db-atom`)
+
+A variável `db-atom` é o coração deste mock. É um `atom` do Clojure, que é um tipo de referência que garante atualizações atômicas e seguras em um ambiente com múltiplas threads. O `atom` envolve um grande mapa aninhado que serve como nosso banco de dados.
+
+A estrutura do mapa é a seguinte:
+
+```clojure
+{
+  "tenant-id-1" {:dados {...} :users {...} :processos {...}},
+  "tenant-id-2" {:dados {...} :users {...} :processos {...}}
+}
+```
+
+- As chaves do mapa principal são os IDs dos *tenants*.
+- Cada *tenant* tem seu próprio mapa contendo seus dados (`:dados`), seus usuários (`:users`) e seus processos (`:processos`).
+- Esta estrutura simula o isolamento de dados da arquitetura multi-tenant.
+
+### O Repositório (`defrecord MockRepository`)
+
+O `defrecord` define um tipo de "objeto" ou "classe" chamado `MockRepository`. Uma instância deste record representa uma conexão com o banco de dados. Ele possui dois campos:
+
+- `db`: Uma referência ao `db-atom` global.
+- `tenant-id`: O ID do *tenant* para o qual este repositório está escopado. **Este campo pode ser `nil`** para repositórios "públicos".
+
+É dentro da definição deste `defrecord` que os protocolos são efetivamente implementados.
+
+### Implementação do `ProcessosRepository`
+
+Esta implementação demonstra o isolamento de *tenant*. Todas as funções aqui utilizam o campo `tenant-id` da instância do `MockRepository` para operar apenas na fatia correta do `db-atom`.
+
+- `(listar-processos [this])`: Acessa `@(:db this)` para obter o mapa do banco de dados, usa `(get (:tenant-id this))` para pegar apenas os dados do *tenant* atual e retorna a lista de seus processos.
+- `(obter-processo-por-id [this id])`: Usa `get-in` para descer diretamente na estrutura de dados do *tenant* atual (`[tenant-id :processos id]`), garantindo que não possa acessar um processo de outro *tenant*.
+- `(criar-processo [this processo])`: Usa `swap!` e `assoc-in` para adicionar um novo processo diretamente no mapa de processos do *tenant* atual.
+
+### Implementação do `AuthRepository`
+
+Esta implementação lida com operações globais.
+
+- `(encontrar-tenant-por-subdominio [this subdominio])`: **Ignora** o campo `tenant-id`. Em vez disso, ele varre os valores de todos os *tenants* no `db-atom` para encontrar aquele cujo subdomínio corresponda.
+- `(encontrar-usuario-por-email [this tenant-id email])`: Recebe o `tenant-id` como argumento e o usa para pesquisar na lista de usuários do *tenant* correto.
+- `(criar-tenant-e-usuario-master [this ...])`: Realiza a operação mais complexa, usando `swap!` e `assoc` para adicionar uma nova chave de primeiro nível (o novo `tenant-id`) ao `db-atom`.
+
+### A Função Construtora (`create-repository`)
+
+Esta é uma função auxiliar que facilita a criação de instâncias do `MockRepository`. É esta função que os `middlewares` chamam. Ela possui duas "aridades" (versões com diferentes números de argumentos):
+
+- `(create-repository)`: Chamada sem argumentos. Retorna um `MockRepository` onde o campo `tenant-id` é `nil`. Este é o repositório **público/global**.
+- `(create-repository tenant-id)`: Chamada com um argumento. Retorna um `MockRepository` onde o campo `tenant-id` está definido. Este é o repositório **isolado/escopado**.

--- a/docs/src-juridico-api-db-protocols-clj.md
+++ b/docs/src-juridico-api-db-protocols-clj.md
@@ -1,0 +1,35 @@
+# Documentação: `src/juridico/api/db/protocols.clj`
+
+## Visão Geral
+
+Este arquivo é um dos pilares da arquitetura da aplicação. Ele utiliza o recurso `defprotocol` do Clojure para definir **contratos** para a camada de persistência de dados. Um protocolo é como uma interface em outras linguagens: ele define um conjunto de funções que devem existir, mas não as implementa.
+
+O objetivo desta abordagem é criar uma **abstração poderosa** que desacopla completamente a lógica de negócio (nos `handlers`) da implementação concreta do banco de dados. Os `handlers` não sabem se os dados estão em um banco de dados em memória, em um PostgreSQL ou em um arquivo de texto. Eles apenas sabem que o objeto de repositório (`db-repo`) que recebem irá satisfazer as funções definidas nestes protocolos.
+
+Este arquivo define dois contratos distintos: um para operações de negócio dentro de um *tenant* e outro para operações globais de autenticação e provisionamento.
+
+---
+
+## Detalhamento dos Protocolos
+
+### `(defprotocol ProcessosRepository ...)`
+
+Este protocolo define o contrato para todas as operações de dados que são **sensíveis ao contexto do tenant**. A ideia principal é que qualquer implementação deste protocolo já deve ter sido configurada com um `tenant-id` específico (isso é feito no `middleware`). Portanto, as funções aqui não precisam receber um `tenant-id` como argumento; o isolamento é uma responsabilidade implícita da implementação.
+
+- **`listar-processos [this]`**
+    - **Contrato:** Deve retornar uma lista de todos os processos jurídicos pertencentes ao *tenant* atual.
+- **`obter-processo-por-id [this id]`**
+    - **Contrato:** Deve buscar e retornar um único processo pelo seu `id`, mas apenas se ele pertencer ao *tenant* atual. Se o processo com aquele `id` existir mas pertencer a outro *tenant*, deve retornar `nil` (como se não existisse).
+- **`criar-processo [this processo]`**
+    - **Contrato:** Deve criar um novo processo no banco de dados, associando-o automaticamente ao *tenant* atual. O mapa `processo` contém os dados a serem inseridos.
+
+### `(defprotocol AuthRepository ...)`
+
+Este protocolo define o contrato para operações que são **globais** ou que atravessam os limites dos *tenants*. É usado principalmente para os fluxos de login e de criação de novas contas. Uma implementação deste protocolo geralmente não terá o escopo de um único *tenant*.
+
+- **`encontrar-tenant-por-subdominio [this subdominio]`**
+    - **Contrato:** Deve buscar e retornar os dados de um *tenant* a partir do seu subdomínio único. Essencial para o processo de login.
+- **`encontrar-usuario-por-email [this tenant-id email]`**
+    - **Contrato:** Deve buscar um usuário pelo seu e-mail, mas **explicitamente dentro do escopo de um `tenant-id` fornecido**. Este design é intencional: o `login-handler` primeiro encontra o *tenant* pelo subdomínio e depois usa o ID do *tenant* para encontrar o usuário, garantindo que o e-mail `admin@empresa.com` do *Tenant A* não seja confundido com o do *Tenant B*.
+- **`criar-tenant-e-usuario-master [this dados-provisionamento]`**
+    - **Contrato:** Uma função de alto nível para orquestrar a criação de um novo *tenant* e seu primeiro usuário administrador (master). O mapa `dados-provisionamento` contém as informações necessárias, como `:company_name` e `:email`.

--- a/docs/src-juridico-api-handlers-clj.md
+++ b/docs/src-juridico-api-handlers-clj.md
@@ -1,0 +1,58 @@
+# Documentação: `src/juridico/api/handlers.clj`
+
+## Visão Geral
+
+Este arquivo contém as funções de "handler", que são o coração da lógica de negócios da API. Cada função é responsável por processar uma requisição para um endpoint específico, interagir com a camada de dados e retornar uma resposta apropriada.
+
+Uma característica fundamental da arquitetura deste arquivo é o **desacoplamento da camada de persistência**. Os handlers não sabem qual banco de dados está sendo usado (PostgreSQL, um banco de dados em memória, etc.). Eles interagem com os dados exclusivamente através de um "contrato" (um `protocol` do Clojure), que é injetado em cada requisição pelo middleware.
+
+---
+
+## Detalhamento do Código
+
+### Dependências (Namespaces Requeridos)
+
+- `juridico.api.db.protocols :as p`: Importa os **contratos** de persistência. Toda a comunicação com o banco de dados é feita através das funções deste namespace (ex: `p/listar-processos`). A implementação real é fornecida em tempo de execução.
+- `clojure.spec.alpha :as s`: A biblioteca principal do Clojure para validação de dados. É usada para garantir que os dados recebidos nos corpos das requisições (payloads) estejam no formato correto antes de serem processados.
+- `juridico.api.specs`: Este namespace contém as definições das `specs` e é carregado para que as `specs` (ex: `:juridico.api.specs/create-process-payload`) fiquem disponíveis para uso.
+
+### O Padrão de um Handler
+
+A maioria dos handlers segue um padrão consistente:
+
+1.  **Recebe a Requisição:** A função recebe o mapa da requisição do Ring.
+2.  **Extrai Dados:** Extrai informações relevantes do mapa, como:
+    - `:db-repo`: O objeto de repositório de banco de dados, injetado pelo middleware. É a "ponte" para a camada de dados.
+    - `:body-params`: O corpo da requisição, já parseado (geralmente de JSON para um mapa Clojure).
+    - `:path-params`: Parâmetros da URL (ex: o `{id}` em `/processos/{id}`).
+3.  **Valida os Dados (se aplicável):** Usa `(s/valid? ...)` para verificar se os `body-params` correspondem à `spec` definida. Se a validação falhar, retorna imediatamente uma resposta `400 Bad Request` com detalhes do erro extraídos de `(s/explain-data ...)`.
+4.  **Executa a Lógica:** Chama as funções do protocolo de persistência (ex: `p/criar-processo`) passando o `db-repo` e os dados necessários.
+5.  **Retorna a Resposta:** Constrói e retorna um mapa de resposta do Ring (ex: `{:status 200 :body ...}`).
+
+---
+
+### Funções de Handler
+
+#### Handlers de Processos (Protegidos por Tenant)
+
+Estes handlers operam no contexto de um *tenant* específico, pois o `db-repo` que eles recebem já foi pré-configurado pelo middleware `wrap-tenant-db-repo`.
+
+- `(listar-processos-handler [req])`: Lista todos os processos para o *tenant* atual.
+- `(obter-processo-handler [req])`: Busca um único processo pelo `id`. Retorna o processo se encontrado, ou um `404 Not Found` caso contrário.
+- `(criar-processo-handler [req])`: Valida o payload de criação e, se for válido, cria um novo processo para o *tenant*.
+
+#### Handlers de Provisionamento e Autenticação (Públicos)
+
+Estes handlers operam em um contexto "global", pois o `db-repo` que eles recebem do middleware `wrap-public-db-repo` não tem escopo de *tenant*.
+
+- `(provision-tenant-handler [req])`:
+    - Valida o payload para criação de um novo *tenant* (nome da empresa, e-mail do admin).
+    - Chama a função de protocolo `p/criar-tenant-e-usuario-master` para realizar o provisionamento.
+    - Retorna os dados do *tenant* criado e uma senha temporária.
+
+- `(login-handler [req])`:
+    - Valida o payload de login (`subdomain`, `email`, `password`).
+    - Primeiro, usa `p/encontrar-tenant-por-subdominio` para identificar para qual *tenant* o login se destina.
+    - Em seguida, usa `p/encontrar-usuario-por-email` (passando o `tenant-id` encontrado) para localizar o usuário dentro do escopo daquele *tenant*.
+    - **Importante:** A verificação de senha (`(= password (:password_hash user))`) é uma **simplificação para a Prova de Conceito (PoC)**. Em um ambiente de produção, esta linha seria substituída por uma verificação de hash criptográfico seguro (ex: usando uma biblioteca como `buddy-hashers`).
+    - Retorna um token JWT simulado em caso de sucesso ou `401 Unauthorized` em caso de falha.

--- a/docs/src-juridico-api-middleware-clj.md
+++ b/docs/src-juridico-api-middleware-clj.md
@@ -1,0 +1,52 @@
+# Documentação: `src/juridico/api/middleware.clj`
+
+## Visão Geral
+
+Este arquivo define os "middlewares" customizados da aplicação. Em uma arquitetura baseada em Ring (o padrão de facto para aplicações web em Clojure), um middleware é uma função de alta ordem que adiciona funcionalidades em torno de um handler de requisição. Eles são usados para tratar de questões transversais como autenticação, logging, gerenciamento de sessão e, neste projeto, **injeção de dependência**.
+
+O papel principal deste namespace é instanciar a implementação **concreta** do repositório de dados e injetá-la no mapa da requisição, para que os `handlers` possam usá-la de forma desacoplada.
+
+**Ponto Importante:** Este é o local do código que decide **qual** implementação de banco de dados será usada. Note que ele depende diretamente de `juridico.api.db.mock`. Se a aplicação fosse migrada para usar PostgreSQL, este seria um dos principais arquivos a serem modificados para instanciar o novo repositório PostgreSQL em vez do `mock`.
+
+---
+
+## Detalhamento do Código
+
+### Dependências (Namespaces Requeridos)
+
+- `juridico.api.db.mock :as db.mock`: Importa a implementação do repositório de banco de dados em memória (`mock`). É a partir daqui que os objetos de repositório são criados.
+
+---
+
+### Funções de Middleware
+
+#### `(wrap-tenant-db-repo [handler])`
+
+Este é o middleware de segurança e contexto para todas as rotas de negócio protegidas (aquelas sob `/api`).
+
+- **Função:** Proteger um endpoint e fornecer-lhe um contexto de banco de dados **isolado por tenant**.
+- **Mecanismo:**
+    1.  Recebe o próximo `handler` na cadeia de processamento.
+    2.  Retorna uma nova função que inspeciona a requisição (`request`).
+    3.  Procura pelo header `x-tenant-id` nos cabeçalhos da requisição.
+    4.  **Se o header `x-tenant-id` existir:**
+        - Cria uma instância do repositório de dados passando o `tenant-id`: `(db.mock/create-repository tenant-id)`. Isto garante que o repositório resultante só possa "ver" os dados pertencentes àquele *tenant*.
+        - Adiciona essa instância ao mapa da requisição sob a chave `:db-repo`.
+        - Chama o `handler` original, passando a requisição modificada.
+    5.  **Se o header `x-tenant-id` NÃO existir:**
+        - Interrompe o processamento da requisição (não chama o `handler`).
+        - Retorna imediatamente uma resposta `401 Unauthorized`, bloqueando o acesso ao recurso.
+
+#### `(wrap-public-db-repo [handler])`
+
+Este é o middleware de contexto para as rotas públicas que ainda precisam de acesso ao banco de dados, como o provisionamento de novos *tenants* ou o login.
+
+- **Função:** Fornecer um contexto de banco de dados **não-isolado** (ou "público").
+- **Mecanismo:**
+    1.  Recebe o próximo `handler` na cadeia.
+    2.  Retorna uma nova função que sempre executa o seguinte:
+    3.  Cria uma instância do repositório de dados **sem** especificar um `tenant-id`: `(db.mock/create-repository)`. Esta instância tem a capacidade de operar em dados de todos os *tenants* (por exemplo, para encontrar um *tenant* pelo subdomínio durante o login).
+    4.  Adiciona essa instância à requisição na chave `:db-repo`.
+    5.  Chama o `handler` original com a requisição modificada.
+
+Esses dois middlewares são, portanto, a peça central que implementa a estratégia de multi-tenancy da aplicação, garantindo que a camada de lógica (`handlers`) receba o "mundo" de dados correto para operar.

--- a/docs/src-juridico-api-specs-clj.md
+++ b/docs/src-juridico-api-specs-clj.md
@@ -1,0 +1,60 @@
+# Documentação: `src/juridico/api/specs.clj`
+
+## Visão Geral
+
+Este arquivo é o "dicionário de dados" da aplicação, definido usando a biblioteca `clojure.spec`. O `clojure.spec` é uma ferramenta poderosa para especificar a "forma" das estruturas de dados. Neste projeto, ele é usado como uma camada de validação na borda da API para garantir que qualquer dado que entre no sistema (via payloads de requisição) esteja correto e completo.
+
+Manter as definições das `specs` em um arquivo centralizado torna a aplicação mais robusta, fácil de entender e de manter. Os `handlers` usam essas `specs` para validar os dados de entrada antes de executar qualquer lógica de negócio.
+
+---
+
+## Detalhamento do Código
+
+### Dependências (Namespaces Requeridos)
+
+- `clojure.spec.alpha :as s`: A biblioteca `clojure.spec`, que fornece todas as funções para definir e usar as especificações (ex: `s/def`, `s/keys`, `s/and`).
+
+---
+
+### Definições de Specs
+
+As `specs` são definidas usando `s/def` com um keyword qualificado (ex: `::email`). Isso registra uma especificação globalmente.
+
+#### Specs para Entidades de Processo
+
+- `::case_number`: Define o número de um processo. Deve ser uma `string` e não pode ser vazia.
+- `::jurisdiction`: Define a jurisdição de um processo. Deve ser uma `string` e não pode ser vazia.
+- `::create-process-payload`: Define a estrutura do corpo da requisição para criar um novo processo.
+    - É um mapa (`s/keys`).
+    - Exige as chaves `:case_number` e `:jurisdiction` (`:req-un`). O valor de cada chave deve estar em conformidade com as `specs` `::case_number` e `::jurisdiction`, respectivamente.
+
+#### Specs para Provisionamento e Login
+
+Estas `specs` definem os contratos para os fluxos de administração de *tenants* e autenticação de usuários.
+
+- `::email`: Define um e-mail válido. Deve ser uma `string` que corresponda à expressão regular `.+@.+\..+`.
+- `::company_name`: Define o nome de uma empresa (*tenant*). Deve ser uma `string` não vazia.
+- `::password`: Define uma senha. Para a PoC, a regra é simples: deve ser uma `string` com mais de 3 caracteres.
+- `::subdomain`: Define um subdomínio. Deve ser uma `string` não vazia.
+
+- `::provision-payload`: Define a estrutura do corpo da requisição para provisionar um novo *tenant*.
+    - Exige as chaves `:company_name` e `:email`.
+
+- `::login-payload`: Define a estrutura do corpo da requisição para o endpoint de login.
+    - Exige as chaves `:subdomain`, `:email`, e `:password`.
+
+### Como as Specs são Utilizadas
+
+No namespace `juridico.api.handlers`, você encontrará um padrão como este:
+
+```clojure
+(if (s/valid? ::login-payload body-params)
+  ;; ... executa a lógica de login ...
+  ;; ... retorna 400 Bad Request com detalhes do erro ...
+  )
+```
+
+- `(s/valid? ::login-payload body-params)`: Verifica se o mapa `body-params` está em conformidade com a `spec` `::login-payload`. Retorna `true` ou `false`.
+- Se a validação falhar, o `handler` retorna uma resposta `400 Bad Request`. Geralmente, o corpo dessa resposta inclui informações de depuração geradas por `(s/explain-data ::login-payload body-params)`, que informa ao cliente exatamente qual parte dos dados estava incorreta.
+
+Essa abordagem impede que dados malformados ou incompletos cheguem à lógica de negócio principal ou à camada de banco de dados.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,58 @@
+### **Diário de Bordo Técnico: Prova de Conceito da Arquitetura Multi-Tenant**
+
+**Data de Referência:** 05 de Setembro de 2025
+**Status:** Prova de Conceito (PoC) da arquitetura multi-tenant concluída e validada funcionalmente em ambiente de produção (Render).
+
+#### **1. Introdução e Objetivos da PoC**
+
+Este documento detalha a implementação e validação da Prova de Conceito (PoC) para a API de um ERP Jurídico, construída sobre uma arquitetura multi-tenant em Clojure. O objetivo primordial desta fase foi validar, em um ambiente simulado porém funcional, os pilares arquitetônicos definidos nos documentos de planejamento, focando em:
+
+1.  **Isolamento de Dados:** Garantir que a lógica da aplicação possa prevenir rigorosamente o acesso a dados entre tenants distintos.
+2.  **Desacoplamento da Persistência:** Implementar uma camada de acesso a dados que seja agnóstica à sua implementação subjacente, utilizando os `protocols` do Clojure.
+3.  **Robustez dos Endpoints:** Assegurar a integridade dos dados na borda da aplicação através de um sistema de validação por contrato (`clojure.spec`).
+4.  **Ciclo de Vida do Tenant:** Validar o fluxo de ponta a ponta, desde o provisionamento de um novo tenant (simulando a ação de um **Super Admin**) até a autenticação do seu respectivo usuário **Admin**.
+
+#### **2. Arquitetura Implementada**
+
+A PoC materializou as seguintes decisões arquitetônicas:
+
+*   **Estratégia de Isolamento de Dados:** Foi adotado o modelo de **Schema Compartilhado com Chave Estrangeira** (`tenant_id`). Para a PoC, este modelo foi simulado através de um `atom` global, cuja estrutura de dados espelha a segregação por `tenant-id`.
+
+* **Padrão Repository via `defprotocol`:** A interação com a camada de dados foi completamente abstraída através de `protocols`. Foram definidos dois contratos principais:
+    * **`ProcessosRepository`**: Define as operações de CRUD para entidades de negócio (e.g., `listar-processos`, `criar-processo`), com a premissa de que a implementação deve ser implicitamente ciente do contexto do tenant.
+    * **`AuthRepository`**: Define as operações globais de autenticação e provisionamento (`encontrar-tenant-por-subdominio`, `criar-tenant-e-usuario-master`), que operam fora do escopo de um único tenant.
+
+* **Injeção de Contexto via Middleware (Ring):** O contexto da requisição (principalmente a identidade do tenant e o repositório de dados) é gerenciado e injetado através de um pipeline de middlewares do Ring:
+    * **`wrap-public-db-repo`**: Um middleware aplicado a rotas não autenticadas (`/admin`, `/auth`). Ele instancia o `MockRepository` sem um `tenant-id` pré-definido, permitindo que os handlers executem operações globais.
+    * **`wrap-tenant-db-repo`**: Um middleware de segurança aplicado a rotas protegidas (`/api`). Para a PoC, ele impõe a presença do header `x-tenant-id`, utiliza este valor para instanciar uma versão do `MockRepository` com escopo definido, e injeta esta instância na requisição. Falhas em encontrar o header resultam em uma resposta `401 Unauthorized`, protegendo os endpoints de negócio.
+
+* **Validação de Contrato com `clojure.spec`:** Para garantir a robustez e a integridade dos dados na borda da API, foi implementada uma camada de validação declarativa. Um namespace centralizado (`juridico.api.specs`) define as "formas" (`specs`) dos payloads de entrada para cada endpoint. Os handlers de requisição atuam como uma barreira de validação, utilizando `(s/valid? ...)` para verificar a conformidade do payload com a `spec` definida. Em caso de não conformidade, a requisição é imediatamente rejeitada com uma resposta `400 Bad Request`, contendo uma descrição detalhada da falha extraída via `(s/explain-data ...)`.
+
+#### **3. Validação Funcional da PoC: Resultados dos Testes**
+
+O fluxo completo foi validado em ambiente de produção (`onrender.com`) através de uma sequência de testes de integração via `curl`.
+
+1.  **Provisionamento do Tenant (Endpoint: `POST /admin/provision-tenant`):**
+    * **Ação:** Requisição enviada com `company_name` e `email` para o usuário **Admin**.
+    * **Resultado:** **SUCESSO (`201 Created`)**. A API invocou corretamente o `provision-tenant-handler`, que utilizou a implementação de `criar-tenant-e-usuario-master` para atualizar o `atom` global com um novo tenant, seu subdomônio gerado e o usuário **Admin** com uma senha temporária. A resposta continha os dados necessários para o próximo passo (subdomínio e senha).
+
+2.  **Autenticação do Usuário (Endpoint: `POST /auth/login`):**
+    * **Ação:** Requisição enviada com `subdomain`, `email` e a `temp_password` obtida no passo anterior.
+    * **Resultado:** **SUCESSO (`200 OK`)**. O `login-handler` validou o payload, utilizou `encontrar-tenant-por-subdominio` para identificar o tenant correto, e subsequentemente usou `encontrar-usuario-por-email` (com o `tenant-id` já isolado) para localizar o usuário e validar a credencial. Um token JWT simulado foi retornado.
+    * **Teste de Falha:** Uma requisição com a senha incorreta resultou em **SUCESSO (`401 Unauthorized`)**, confirmando a lógica de validação de credenciais.
+
+3.  **Acesso a Recursos Protegidos (Endpoint: `GET /api/processos` e derivados):**
+    * **Validação de Dados:** Uma requisição `POST /api/processos` com payload incompleto resultou em **SUCESSO (`400 Bad Request`)**, validando a barreira de proteção do `clojure.spec`.
+    * **Isolamento de Tenant (Teste Crítico de Segurança):**
+        * `GET /api/processos` com `X-Tenant-ID: tenant-1` retornou a lista de processos pertencente **apenas** ao tenant 1.
+        * `GET /api/processos` com `X-Tenant-ID: tenant-2` retornou a lista de processos pertencente **apenas** ao tenant 2.
+        * `GET /api/processos/proc-333` (recurso do tenant 2) com `X-Tenant-ID: tenant-1` resultou em **SUCESSO (`404 Not Found`)**. Este teste confirmou que a lógica de busca no repositório está corretamente encapsulando a consulta dentro do escopo do `tenant-id` injetado pelo middleware, prevenindo efetivamente o vazamento de dados entre tenants.
+    * **Validação do Middleware de Autenticação:** Uma requisição a `/api/processos` sem o header `X-Tenant-ID` resultou em **SUCESSO (`401 Unauthorized`)**, confirmando que o `wrap-tenant-db-repo` está protegendo corretamente os endpoints de negócio.
+
+#### **4. Próximos Passos Arquitetônicos**
+
+A PoC validou com sucesso as premissas fundamentais da arquitetura. A evolução para o produto final seguirá o plano de implementação, focando em:
+
+1.  **Implementação de Autenticação Stateless com JWT:** Substituir a autenticação simulada por um sistema robusto baseado em JWTs, utilizando a biblioteca `buddy-auth`. O `tenant_id` e a `role` do usuário passarão a ser *claims* dentro do payload do JWT, tornando-se a fonte da verdade para o contexto do usuário em requisições subsequentes. O header `X-Tenant-ID` será preterido em favor do `Authorization: Bearer <token>`.
+2.  **Migração da Persistência para PostgreSQL:** Substituir a implementação do `MockRepository` por uma nova que interaja com um banco de dados PostgreSQL. Graças ao desacoplamento provido pelos `protocols`, esta migração não exigirá alterações na camada de `handlers` ou na lógica de negócio.
+3.  **Identificação de Tenant por Subdomínio:** Evoluir o mecanismo de identificação de tenant para analisar o subdomínio do host da requisição, conforme definido na arquitetura final, substituindo a dependência do header `X-Tenant-ID` na fase de login.


### PR DESCRIPTION
Creates a new `docs` directory and populates it with detailed documentation for every file in the project.

- Each source file (`.clj`), configuration file (`.gitignore`, `Dockerfile`, `project.clj`), and the `README.md` now has a corresponding explanatory markdown file in the `docs` directory.
- Adds a `docs/status.md` file containing the project's technical logbook as provided.
- The documentation is written to be detailed and informative, with the goal of being accessible to junior developers.
- Updates the main `README.md` to correct outdated file paths and run commands, ensuring it is synchronized with the current state of the codebase.