### PR TITLE
feat: Implement RBAC for operator management

### DIFF
--- a/src/juridico/api/core.clj
+++ b/src/juridico/api/core.clj
@@ -41,7 +41,15 @@
 
     ["/processos/{id}"
      {:get {:handler h/obter-processo-handler
-            :name :processos/get-by-id}}]]])
+            :name :processos/get-by-id}}]
+
+    ;; --- ROTAS DE GESTÃO DE OPERADORES (acessíveis apenas pelo 'master') ---
+    ["/operadores"
+     {:middleware [mw/wrap-master-role-authorization] ; <--- APLICA A PROTEÇÃO DE PAPEL AQUI
+      :get {:handler h/listar-operadores-handler
+            :name :operadores/list}
+      :post {:handler h/criar-operador-handler
+             :name :operadores/create}}]]])
 
 ;; --- Handler Principal da Aplicação ---
 (def app

--- a/src/juridico/api/db/postgres.clj
+++ b/src/juridico/api/db/postgres.clj
@@ -72,9 +72,21 @@
                                        :role "master"} 
                                       {:return-keys true})]
             {:tenant {:id new-tenant-id :subdomain subdomain :company_name company_name}
-             :user {:email email :temp_password temp-password}}))))))
+             :user {:email email :temp_password temp-password}})))))
 
-;; --- FUNÇÃO CONSTRUTORA ---
+  ;; --- IMPLEMENTAÇÃO DAS NOVAS FUNÇÕES ---
+  (listar-usuarios-do-tenant [this tenant-id]
+    ;; Retorna todos os utilizadores, mas omite o hash da palavra-passe por segurança
+    (sql/query db-conn ["SELECT id, email, full_name, role FROM users WHERE tenant_id = ?" tenant-id]))
+
+  (criar-usuario-operador [this tenant-id {:keys [email password full_name]}]
+    (sql/insert! db-conn :users {:tenant_id     tenant-id
+                                 :email         email
+                                 :full_name     full_name
+                                 :password_hash (hashers/encrypt password)
+                                 :role          "operador"})))
+
+;; --- FUNÇÃO CONSTRUTora ---
 (defn create-repository
   ([] (->PostgresRepository @datasource nil))
   ([tenant-id] (->PostgresRepository @datasource tenant-id)))

--- a/src/juridico/api/db/protocols.clj
+++ b/src/juridico/api/db/protocols.clj
@@ -27,6 +27,11 @@
     "Busca um usuário pelo seu e-mail, dentro do escopo de um tenant específico.")
 
   (criar-tenant-e-usuario-master [this dados-provisionamento]
-    "Cria um novo tenant e seu primeiro usuário (master).
-     Espera um mapa com :company_name e :master_user_email.
-     Retorna um mapa com os dados do tenant e do usuário criados."))
+    "Cria um novo tenant e seu primeiro usuário (master).")
+
+  ;; --- NOVAS FUNÇÕES ADICIONADAS AQUI ---
+  (listar-usuarios-do-tenant [this tenant-id]
+    "Retorna uma lista de todos os usuários de um tenant específico.")
+
+  (criar-usuario-operador [this tenant-id dados-usuario]
+    "Cria um novo usuário com a role 'operador' para um tenant específico."))

--- a/src/juridico/api/handlers.clj
+++ b/src/juridico/api/handlers.clj
@@ -81,3 +81,24 @@
     {:status 400
      :body {:error "Dados de login inválidos."
             :details (s/explain-data :juridico.api.specs/login-payload body-params)}}))
+
+;; --- HANDLERS DE GESTÃO DE OPERADORES (Protegidos por Role) ---
+
+(defn listar-operadores-handler
+  "Handler para o 'master' listar todos os usuários do seu tenant."
+  [{:keys [db-repo identity]}]
+  (let [tenant-id (:tenant-id identity)]
+    {:status 200
+     :body (p/listar-usuarios-do-tenant db-repo tenant-id)}))
+
+(defn criar-operador-handler
+  "Handler para o 'master' criar um novo usuário 'operador' no seu tenant."
+  [{:keys [db-repo body-params identity]}]
+  (if (s/valid? :juridico.api.specs/create-operator-payload body-params)
+    (let [tenant-id (:tenant-id identity)
+          novo-operador (p/criar-usuario-operador db-repo tenant-id body-params)]
+      {:status 201
+       :body (dissoc novo-operador :password_hash)}) ; Remove o hash da senha da resposta
+    {:status 400
+     :body {:error "Dados de entrada para criar operador são inválidos."
+            :details (s/explain-data :juridico.api.specs/create-operator-payload body-params)}}))

--- a/src/juridico/api/middleware.clj
+++ b/src/juridico/api/middleware.clj
@@ -66,3 +66,14 @@
     (let [repo (db/create-repository)
           request' (assoc request :db-repo repo)]
       (handler request'))))
+
+(defn wrap-master-role-authorization
+  "Middleware que verifica se o usuário autenticado tem a role 'master'."
+  [handler]
+  (fn [request]
+    (let [role (get-in request [:identity :role])]
+      (if (= role "master")
+        (handler request)
+        {:status 403
+         :headers {"Content-Type" "application/json"}
+         :body "{\"error\": \"Acesso negado. Requer permissão de administrador.\"}"}))))

--- a/src/juridico/api/specs.clj
+++ b/src/juridico/api/specs.clj
@@ -26,4 +26,9 @@
 
 ;; Define a estrutura do payload para a tela de login.
 ;; AGORA SÓ ESPERA e-mail e senha. O subdomínio é identificado pelo Host da requisição.
-(s/def ::login-payload (s/keys :req-un [::email ::password])) 
+(s/def ::login-payload (s/keys :req-un [::email ::password]))
+
+;; --- Specs para Gestão de Usuários ---
+(s/def ::full_name (s/and string? not-empty))
+
+(s/def ::create-operator-payload (s/keys :req-un [::email ::password ::full_name]))


### PR DESCRIPTION
This commit introduces Role-Based Access Control (RBAC) to allow users with the 'master' role to manage 'operador' users within their own tenant.

The following changes have been made:

- A new middleware `wrap-master-role-authorization` was created to restrict access to master users.
- New API endpoints `GET /api/operadores` and `POST /api/operadores` were created to list and create operators, respectively.
- The persistence layer was extended to support listing and creating users within a tenant.
- The new routes are protected by the authorization middleware, ensuring only master users can access them.