### PR TITLE
docs: Update documentation to reflect production state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # API de ERP Jurídico - Backend em Clojure
 
-Este projeto é a estrutura inicial para uma API REST de um ERP jurídico, construída em Clojure. A principal característica arquitetural é o suporte a multi-tenancy desde o início, utilizando uma camada de abstração (Padrão Repository) que permite a fácil substituição do banco de dados mock atual por um banco de dados real no futuro.
+Este projeto é a API REST para um ERP jurídico, construída em Clojure. A arquitetura foi projetada para ser uma fundação de produção robusta, com suporte a multi-tenancy, persistência de dados em PostgreSQL e Controle de Acesso Baseado em Papel (RBAC).
 
 ## Arquitetura Aplicada
 
 A arquitetura foi desenhada para ser modular, testável e escalável.
 
-1.  **Padrão Repository com `protocol`**: Toda a interação com dados é mediada por um "contrato" definido em `juridico.api.db.protocols`. Isso desacopla a lógica de negócio dos detalhes de implementação do banco de dados. Para trocar o banco de dados, basta criar um novo `defrecord` que implemente o mesmo protocolo.
+1.  **Persistência com PostgreSQL (CockroachDB)**: A camada de dados utiliza um cluster CockroachDB (compatível com PostgreSQL) para garantir a permanência e a segurança dos dados. A interação com o banco de dados é gerenciada pela biblioteca `next.jdbc`.
 
-2.  **Banco de Dados Mock com `atom`**: Para desenvolvimento e testes, um `atom` global em `juridico.api.db.mock` simula o banco de dados. Ele é pré-populado com dados para dois tenants (`tenant-1` e `tenant-2`) para permitir a verificação do isolamento de dados.
+2.  **Padrão Repository com `protocol`**: Toda a interação com dados é mediada por um "contrato" definido em `juridico.api.db.protocols`. Isso desacopla a lógica de negócio dos detalhes de implementação do banco de dados. A implementação atual, `PostgresRepository`, traduz as funções do protocolo para consultas SQL.
 
-3.  **Injeção de Dependência via Middleware**: Middlewares customizados (`juridico.api.middleware`) interceptam cada requisição, identificam o contexto (público ou de *tenant*) e instanciam o repositório correto. Este repositório, já configurado para o escopo necessário, é então "injetado" na requisição, ficando disponível para os handlers.
-
-4.  **Roteamento com Reitit**: As rotas da API, a negociação de conteúdo (JSON) e a aplicação de middlewares são gerenciadas pela biblioteca Reitit, que oferece uma forma declarativa e eficiente de definir os endpoints.
+3.  **Autenticação e Autorização (RBAC)**:
+    *   **Autenticação Stateless com JWT**: O login de um usuário gera um token JWT que contém claims essenciais como `tenant-id` e `role`.
+    *   **Injeção de Dependência e Contexto**: Um middleware de autenticação valida o token em cada requisição e injeta a identidade do usuário (incluindo o `tenant-id`) na requisição. Isso garante o isolamento de dados entre os tenants.
+    *   **Controle de Acesso (RBAC)**: Middlewares de autorização, como `wrap-master-role-authorization`, inspecionam a `role` do usuário no token para proteger rotas específicas, permitindo ou negando o acesso com base nas permissões.
 
 ## Estrutura de Arquivos
 
-O projeto está organizado da seguinte forma para promover a separação de responsabilidades:
+O projeto está organizado da seguinte forma:
 
 ```
 /src
@@ -25,9 +26,10 @@ O projeto está organizado da seguinte forma para promover a separação de resp
         ├── core.clj          # Ponto de entrada: define rotas, aplica middlewares e inicia o servidor.
         ├── db
         │   ├── protocols.clj # Define o "contrato" (protocol) da camada de dados.
-        │   └── mock.clj      # Implementação do banco de dados mock com `atom` e o `defrecord` do repositório.
-        ├── middleware.clj    # Middlewares customizados para injeção de dependência e contexto.
-        ├── handlers.clj      # Lógica dos handlers da API, que orquestram as requisições.
+        │   ├── postgres.clj  # Implementação do repositório com PostgreSQL.
+        │   └── mock.clj      # Implementação mock (usada para testes mais antigos).
+        ├── middleware.clj    # Middlewares para autenticação, autorização (RBAC) e injeção de contexto.
+        ├── handlers.clj      # Lógica dos handlers da API.
         └── specs.clj         # Definições de `clojure.spec` para validação de dados.
 ```
 
@@ -36,8 +38,16 @@ O projeto está organizado da seguinte forma para promover a separação de resp
 **Pré-requisitos:**
 *   [Java Development Kit (JDK)](https://www.oracle.com/java/technologies/downloads/)
 *   [Leiningen](https://leiningen.org/)
+*   Acesso a um cluster PostgreSQL / CockroachDB.
 
-Com os pré-requisitos instalados, inicie o servidor com o seguinte comando a partir da raiz do projeto:
+**Configuração:**
+1.  Crie uma variável de ambiente `DATABASE_URL` com a string de conexão para o seu banco de dados.
+    *Exemplo:*
+    ```bash
+    export DATABASE_URL="postgresql://user:password@host:port/database?sslmode=require"
+    ```
+
+Com os pré-requisitos instalados e a variável de ambiente configurada, inicie o servidor:
 
 ```bash
 lein run
@@ -47,66 +57,44 @@ O servidor será iniciado na porta `3000` por padrão, ou na porta definida pela
 
 ## Como Testar a API
 
-Use `curl` ou uma ferramenta de sua preferência para fazer requisições à API.
+Use `curl` ou uma ferramenta de sua preferência para fazer requisições à API. O fluxo abaixo demonstra a criação e gestão de usuários "operadores" por um usuário "master".
 
-### Testes de Provisionamento e Autenticação
-
-**1. Provisionar um novo Tenant**
-*Cria um novo tenant e seu usuário admin. Retorna o subdomínio e a senha temporária.*
+**Variáveis de Ambiente (Exemplo):**
 ```bash
-curl -i -X POST \
+# URL da API
+API_URL="http://localhost:3000"
+
+# Token do usuário "master" (obtido após o login)
+MASTER_TOKEN="SEU_TOKEN_DE_MASTER_AQUI"
+
+# Token do usuário "operador" (obtido após o login com as credenciais do operador criado)
+OPERATOR_TOKEN="SEU_TOKEN_DE_OPERADOR_AQUI"
+```
+
+### Testes de Gestão de Operadores (RBAC)
+
+**1. Criar um novo Operador (como Master)**
+*Um usuário "master" cria um novo usuário com a role "operador" dentro do seu próprio tenant.*
+*Deve retornar `201 Created`.*
+```bash
+curl -i -X POST "$API_URL/api/operadores" \
+  -H "Authorization: Bearer $MASTER_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"company_name": "Nova Advocacia", "email": "admin@nova.com"}' \
-  http://localhost:3000/admin/provision-tenant
+  -d '{"full_name": "Fulano de Tal", "email": "fulano@operador.com", "password": "uma_senha_forte"}'
 ```
 
-**2. Autenticar (Login)**
-*Usa os dados do passo anterior para simular um login. Retorna um token JWT simulado.*
+**2. Listar Operadores (como Master)**
+*O usuário "master" lista todos os usuários do seu tenant. A resposta deve incluir o próprio master e o operador recém-criado.*
+*Deve retornar `200 OK`.*
 ```bash
-curl -i -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"subdomain": "nova-advocacia", "email": "admin@nova.com", "password": "SENHA_TEMPORARIA_RECEBIDA"}' \
-  http://localhost:3000/auth/login
+curl -i -X GET "$API_URL/api/operadores" \
+  -H "Authorization: Bearer $MASTER_TOKEN"
 ```
 
-### Testes de API Protegida (Exige `X-Tenant-ID`)
-
-**3. Listar processos (Tenant 1)**
-*Deve retornar 2 processos.*
+**3. Tentar Listar Operadores (como Operador)**
+*Um usuário "operador" tenta acessar a mesma rota de listagem.*
+*Deve retornar `403 Forbidden`, confirmando que o middleware de autorização está funcionando.*
 ```bash
-curl -i -H "X-Tenant-ID: tenant-1" http://localhost:3000/api/processos
-```
-
-**4. Listar processos (Tenant 2)**
-*Deve retornar 1 processo.*
-```bash
-curl -i -H "X-Tenant-ID: tenant-2" http://localhost:3000/api/processos
-```
-
-**5. Obter processo por ID (Sucesso)**
-*Busca um processo que pertence ao Tenant 1.*
-```bash
-curl -i -H "X-Tenant-ID: tenant-1" http://localhost:3000/api/processos/proc-111
-```
-
-**6. Obter processo por ID (Falha - Isolamento de Tenant)**
-*Tenta buscar um processo do Tenant 2 usando as credenciais do Tenant 1. Deve retornar 404 Not Found.*
-```bash
-curl -i -H "X-Tenant-ID: tenant-1" http://localhost:3000/api/processos/proc-333
-```
-
-**7. Criar um novo processo (Tenant 2)**
-*Cria um novo processo para o Tenant 2.*
-```bash
-curl -i -X POST \
-  -H "Content-Type: application/json" \
-  -H "X-Tenant-ID: tenant-2" \
-  -d '{"case_number": "XYZ-987", "jurisdiction": "Supremo Tribunal Federal"}' \
-  http://localhost:3000/api/processos
-```
-
-**8. Requisição sem Tenant ID**
-*Deve retornar um erro 401 Unauthorized.*
-```bash
-curl -i http://localhost:3000/api/processos
+curl -i -X GET "$API_URL/api/operadores" \
+  -H "Authorization: Bearer $OPERATOR_TOKEN"
 ```

--- a/docs/status.md
+++ b/docs/status.md
@@ -68,3 +68,55 @@ Com a PoC e a autenticação JWT validadas, a evolução para o produto final se
 
 1.  **Migração da Persistência para PostgreSQL:** Substituir a implementação do `MockRepository` por uma nova que interaja com um banco de dados PostgreSQL. Graças ao desacoplamento provido pelos `protocols`, esta migração não exigirá alterações na camada de `handlers` ou na lógica de negócio.
 2.  **Identificação de Tenant por Subdomínio na Requisição:** Evoluir o mecanismo de identificação de tenant para analisar o subdomínio do host da requisição (e.g., `tenant-a.meuerp.com`), conforme definido na arquitetura final. Isso simplificará o processo de login, eliminando a necessidade de enviar o `subdomain` no corpo da requisição.
+
+---
+
+### **Etapa 3: Migração para PostgreSQL e Implementação de RBAC**
+
+**Data de Referência:** 16 de Setembro de 2025
+**Status:** Fase de produção iniciada. A persistência em memória foi substituída por um banco de dados PostgreSQL (CockroachDB) e o primeiro fluxo de autorização baseado em papéis (RBAC) foi implementado.
+
+#### **3.1. Migração da Camada de Persistência para PostgreSQL (CockroachDB)**
+
+A camada de dados, que antes utilizava um `atom` do Clojure para simulação, foi migrada para um cluster CockroachDB, compatível com o protocolo PostgreSQL, garantindo a permanência e a segurança dos dados.
+
+*   **Estrutura do Banco de Dados:**
+    *   **Tabelas Criadas:** `tenants`, `users`, `legal_cases`.
+    *   **Constraints de Integridade:** `UNIQUE` na coluna `subdomain` da tabela `tenants`, e `FOREIGN KEY` com `ON DELETE CASCADE` na coluna `tenant_id` das tabelas `users` e `legal_cases` para garantir o isolamento e a integridade referencial dos dados.
+    *   **Segurança:** `UNIQUE` na combinação de `(tenant_id, email)` na tabela `users` para impedir emails duplicados dentro do mesmo tenant.
+
+*   **Alterações na Aplicação Clojure:**
+    *   **Dependências:** Adicionadas `[com.github.seancorfield/next.jdbc "1.3.894"]` e `[org.postgresql/postgresql "42.7.3"]` ao `project.clj`.
+    *   **Nova Camada de Persistência (`postgres.clj`):** Criado o namespace `juridico.api.db.postgres` com um `defrecord PostgresRepository` que implementa os protocolos `ProcessosRepository` e `AuthRepository`, traduzindo cada função para consultas SQL.
+    *   **Lógica de Conexão Robusta:**
+        *   **Inicialização Atrasada (`delay`):** A criação do datasource foi encapsulada para evitar a tentativa de conexão durante a compilação AOT.
+        *   **Parsing da URL de Conexão:** Uma nova função `parse-db-url` foi criada para desmontar a `DATABASE_URL` via regex, resolvendo problemas de parsing do driver JDBC (`UnknownHostException`).
+        *   **Configuração de SSL:** O parâmetro `:sslmode "require"` foi adicionado para garantir a conexão segura com o cluster CockroachDB.
+        *   **Recuperação de Chaves Geradas:** O código foi ajustado para ler a chave qualificada `:tenants/id` retornada pelo `next.jdbc` após inserções, resolvendo `not-null constraint violation` na criação de usuários.
+
+#### **3.2. Implementação do Controle de Acesso Baseado em Papel (RBAC)**
+
+Com a base de dados funcional, a camada de segurança foi aprimorada para autorizar ações com base no papel do usuário.
+
+*   **Middleware de Autorização (`wrap-master-role-authorization`):**
+    *   Um novo middleware foi criado em `juridico.api.middleware`.
+    *   Ele inspeciona a `role` na identidade do token JWT. Se a `role` for `"master"`, a requisição prossegue; caso contrário, é retornada uma resposta `403 Forbidden`.
+
+*   **Proteção de Rotas:**
+    *   No arquivo `juridico.api.core.clj`, um novo aninhamento de rotas `/api/operadores` foi criado.
+    *   O middleware `wrap-master-role-authorization` foi aplicado a este aninhamento, protegendo todos os endpoints (GET, POST) e garantindo que sejam acessíveis apenas por usuários "master".
+
+#### **3.3. Funcionalidade de Gestão de Operadores (Primeira Feature RBAC)**
+
+*   **Extensão da Camada de Dados:**
+    *   O protocolo `AuthRepository` foi estendido com as funções `listar-usuarios-do-tenant` e `criar-usuario-operador`.
+    *   **Implementação em `postgres.clj`:**
+        *   `listar-usuarios-do-tenant`: Executa um `SELECT` na tabela `users` omitindo o `password_hash` por segurança.
+        *   `criar-usuario-operador`: Executa um `INSERT` na tabela `users`, criptografando a senha com `buddy.hashers` e fixando a `role` como `"operador"`.
+
+*   **Novos Handlers e Specs:**
+    *   Criados os handlers `listar-operadores-handler` e `criar-operador-handler`, que extraem o `tenant-id` diretamente da identidade do token JWT.
+    *   Definida a spec `::create-operator-payload` para validar as requisições de criação.
+
+*   **Validação em Produção:**
+    *   A funcionalidade foi validada de ponta a ponta com testes `curl`, confirmando que usuários "master" podem criar e listar operadores, e que operadores recebem um token com a `role` correta e são bloqueados pelo middleware de autorização ao tentar acessar recursos protegidos.


### PR DESCRIPTION
Updates the project's documentation to align with the recent architectural evolution from a Proof of Concept to a production-ready foundation.

Key changes reflected in the documentation:
- Migration of the persistence layer from an in-memory atom to a PostgreSQL (CockroachDB) database.
- Implementation of Role-Based Access Control (RBAC) using the 'role' claim from the JWT.
- Addition of the first RBAC-based feature: management of 'operator' users by a 'master' user.

The `README.md` has been rewritten to serve as an up-to-date guide for new developers, including new setup instructions and API usage examples.

The `docs/status.md` developer diary has been updated with a new entry to preserve the historical log of these changes.