### PR TITLE
Refactor: Centralize JWT secret key

### DIFF
--- a/src/juridico/api/config.clj
+++ b/src/juridico/api/config.clj
@@ -1,0 +1,5 @@
+(ns juridico.api.config)
+
+(def jwt-secret
+  (or (System/getenv "JWT_SECRET")
+      "chave-padrao-para-desenvolvimento-segura"))

--- a/src/juridico/api/handlers.clj
+++ b/src/juridico/api/handlers.clj
@@ -4,11 +4,8 @@
             [juridico.api.specs]
             [buddy.sign.jwt :as jwt]
             [buddy.hashers :as hashers]
-            [juridico.api.services.email :as email-service]))
-
-;; --- CONFIGURAÇÃO DE SEGURANÇA ---
-;; A chave secreta é lida da variável de ambiente, centralizando a configuração.
-(def jwt-secret (or (System/getenv "JWT_SECRET") "chave-padrao-para-desenvolvimento-segura"))
+            [juridico.api.services.email :as email-service]
+            [juridico.api.config :as config]))
 
 
 ;; --- HANDLERS DE PROCESSOS (Protegidos por JWT) ---
@@ -95,7 +92,7 @@
                         :exp (-> (java.time.Instant/now)
                                  (.plusSeconds 3600)
                                  (.getEpochSecond))}
-                token (jwt/sign claims jwt-secret)]
+                token (jwt/sign claims config/jwt-secret)]
             {:status 200
              :body {:message (str "Usuário " email " autenticado com sucesso.")
                     :token token}})
@@ -155,4 +152,4 @@
   "Endpoint temporário para verificar os primeiros caracteres da JWT_SECRET."
   [request]
   {:status 200
-   :body {:secret_start (subs jwt-secret 0 4)}})
+   :body {:secret_start (subs config/jwt-secret 0 4)}})

--- a/src/juridico/api/middleware.clj
+++ b/src/juridico/api/middleware.clj
@@ -2,9 +2,8 @@
   (:require [juridico.api.db.postgres :as db]
             [juridico.api.db.protocols :as p]
             [buddy.sign.jwt :as jwt]
-            [clojure.string :as str]))
-
-(def jwt-secret (or (System/getenv "JWT_SECRET") "chave-padrao-para-desenvolvimento-segura"))
+            [clojure.string :as str]
+            [juridico.api.config :as config]))
 
 (defn wrap-tenant-context
   "Middleware que identifica o tenant a partir de um cabeçalho customizado (para teste) ou do subdomínio."
@@ -40,7 +39,7 @@
   (fn [request]
     (try
       (if-let [token (extract-token request)]
-        (let [claims (jwt/unsign token jwt-secret)
+        (let [claims (jwt/unsign token config/jwt-secret)
               tenant-id (:tenant-id claims)]
           (if tenant-id
             (let [repo (db/create-repository tenant-id)


### PR DESCRIPTION
A new file `src/juridico/api/config.clj` was created to store the JWT secret key.

The files `src/juridico/api/handlers.clj` and `src/juridico/api/middleware.clj` were updated to remove the local definition of the secret and use the new centralized configuration.