### PR TITLE
feat: add get by id for operadores

### DIFF
--- a/src/juridico/api/core.clj
+++ b/src/juridico/api/core.clj
@@ -56,6 +56,8 @@
 
     ["/operadores/{id}"
      {:middleware [mw/wrap-master-role-authorization]
+      :get {:handler h/obter-operador-handler
+            :name :operadores/get-by-id}
       :put {:handler h/atualizar-operador-handler
             :name :operadores/update}
       :delete {:handler h/deletar-operador-handler

--- a/src/juridico/api/db/mock.clj
+++ b/src/juridico/api/db/mock.clj
@@ -85,7 +85,43 @@
         :processos {}})
 
       {:tenant {:id new-tenant-id :subdomain subdomain}
-       :user {:email email :temp_password temp-password}})))
+       :user {:email email :temp_password temp-password}}))
+
+  ;; --- Implementação das Funções de Operadores ---
+  (listar-usuarios-do-tenant [this tenant-id]
+    (let [usuarios (-> @(:db this) (get-in [tenant-id :users]) vals)]
+      (map #(dissoc % :password_hash) usuarios)))
+
+  (obter-operador-por-id [this tenant-id user-id]
+    (let [user (-> @(:db this) (get-in [tenant-id :users user-id]))]
+      (when user
+        (dissoc user :password_hash))))
+
+  (criar-usuario-operador [this tenant-id {:keys [email password full_name]}]
+    (let [new-user-id (str "user-" (rand-int 10000))
+          novo-operador {:id new-user-id
+                         :email email
+                         :full_name full_name
+                         :password_hash (hashers/encrypt password)
+                         :role "operador"}]
+      (swap! (:db this) assoc-in [tenant-id :users new-user-id] novo-operador)
+      (dissoc novo-operador :password_hash)))
+
+  (atualizar-operador [this tenant-id user-id dados-usuario]
+    (let [user-path [tenant-id :users user-id]]
+      (if (get-in @(:db this) user-path)
+        (do
+          (swap! (:db this) update-in user-path merge (select-keys dados-usuario [:full_name]))
+          {:next.jdbc/update-count 1})
+        {:next.jdbc/update-count 0})))
+
+  (deletar-operador [this tenant-id user-id]
+    (let [user-path [tenant-id :users user-id]]
+      (if (get-in @(:db this) user-path)
+        (do
+          (swap! (:db this) update-in [tenant-id :users] dissoc user-id)
+          {:next.jdbc/update-count 1})
+        {:next.jdbc/update-count 0})))))
 
 
 (defn create-repository

--- a/src/juridico/api/db/protocols.clj
+++ b/src/juridico/api/db/protocols.clj
@@ -46,4 +46,7 @@
     "Atualiza os dados de um operador.")
 
   (deletar-operador [this tenant-id user-id]
-    "Deleta um usuário operador."))
+    "Deleta um usuário operador.")
+
+  (obter-operador-por-id [this tenant-id user-id]
+    "Busca um operador específico pelo seu ID."))

--- a/src/juridico/api/handlers.clj
+++ b/src/juridico/api/handlers.clj
@@ -112,6 +112,15 @@
     {:status 200
      :body (p/listar-usuarios-do-tenant db-repo tenant-id)}))
 
+(defn obter-operador-handler
+  "Handler para obter um operador específico por ID."
+  [{:keys [db-repo path-params identity]}]
+  (let [tenant-id (:tenant-id identity)
+        user-id (Long/parseLong (:id path-params))]
+    (if-let [operador (p/obter-operador-por-id db-repo tenant-id user-id)]
+      {:status 200 :body operador}
+      {:status 404 :body {:error "Operador não encontrado."}})))
+
 (defn criar-operador-handler
   "Handler para o 'master' criar um novo usuário 'operador' no seu tenant."
   [{:keys [db-repo body-params identity]}]


### PR DESCRIPTION
This commit completes the CRUD functionality for the 'operadores' resource by adding the missing 'get by id' operation.

It introduces a new route `GET /operadores/{id}`, a corresponding handler `obter-operador-handler`, and the necessary database protocol function `obter-operador-por-id`.

Additionally, this commit fixes a bug where the mock database implementation in `src/juridico/api/db/mock.clj` was incomplete and out of sync with the `AuthRepository` protocol. The mock implementation is now complete, improving the testability of the application.