### PR TITLE
fix: implement obter-operador-por-id in postgres repository

### DIFF
--- a/src/juridico/api/db/postgres.clj
+++ b/src/juridico/api/db/postgres.clj
@@ -85,6 +85,9 @@
     ;; Retorna todos os utilizadores, mas omite o hash da palavra-passe por segurança
     (sql/query db-conn ["SELECT id, email, full_name, role FROM users WHERE tenant_id = ?" tenant-id]))
 
+  (obter-operador-por-id [this tenant-id user-id]
+    (first (sql/query db-conn ["SELECT id, email, full_name, role FROM users WHERE tenant_id = ? AND id = ?" tenant-id user-id])))
+
   (criar-usuario-operador [this tenant-id {:keys [email password full_name]}]
     (sql/insert! db-conn :users {:tenant_id     tenant-id
                                  :email         email


### PR DESCRIPTION
This commit fixes a 500 error caused by a missing implementation of the 'obter-operador-por-id' function in the 'PostgresRepository'.

The function was defined in the protocol and implemented for the mock database, but was missing from the production PostgreSQL implementation, causing an 'AbstractMethodError' when the GET /api/operadores/{id} endpoint was called.