### PR TITLE
docs: add curl example for get operator by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,12 @@ curl -i -X GET "$API_URL/api/operadores" \
 curl -i -X GET "$API_URL/api/operadores" \
   -H "Authorization: Bearer $OPERATOR_TOKEN"
 ```
+
+**4. Obter um Operador por ID (como Master)**
+*O usuário "master" busca um operador específico pelo seu ID.*
+*Deve retornar `200 OK` com os dados do operador.*
+```bash
+# Substitua {ID_DO_OPERADOR} pelo ID real
+curl -i -X GET "$API_URL/api/operadores/{ID_DO_OPERADOR}" \
+  -H "Authorization: Bearer $MASTER_TOKEN"
+```


### PR DESCRIPTION
This commit updates the "Como Testar a API" section of the README.md file.

It adds a new example demonstrating how to fetch a single operator by their ID using the `GET /api/operadores/{id}` endpoint.