### PR TITLE
feat: Implement operator limit and tenant CRUD

### DIFF
--- a/src/juridico/api/core.clj
+++ b/src/juridico/api/core.clj
@@ -14,11 +14,29 @@
    ["/debug"
     ["/secret-check" {:get {:handler h/secret-check-handler}}]]
 
-   ;; --- ROTAS DE ADMINISTRAÇÃO (sem contexto de tenant) ---
-   ["/admin" {:middleware [mw/wrap-public-db-repo]}
+   ;; --- ROTAS DE ADMINISTRAÇÃO (protegidas para Super Admin) ---
+   ["/admin"
+    {:middleware [mw/wrap-jwt-authentication
+                  mw/wrap-super-admin-authorization
+                  mw/wrap-public-db-repo]}
+
     ["/provision-tenant"
      {:post {:handler h/provision-tenant-handler
-             :name :admin/provision}}]]
+             :name :admin/provision}}]
+
+    ["/tenants"
+     {:get {:handler h/listar-tenants-handler
+            :name :admin/list-tenants}
+      :post {:handler h/criar-tenant-handler
+             :name :admin/create-tenant}}]
+
+    ["/tenants/{id}"
+     {:get {:handler h/obter-tenant-handler
+            :name :admin/get-tenant}
+      :put {:handler h/atualizar-tenant-handler
+            :name :admin/update-tenant}
+      :delete {:handler h/deletar-tenant-handler
+               :name :admin/delete-tenant}}]]
 
    ;; --- ROTAS DE AUTENTICAÇÃO (com contexto de tenant) ---
    ["/auth" {:middleware [mw/wrap-public-db-repo

--- a/src/juridico/api/db/postgres.clj
+++ b/src/juridico/api/db/postgres.clj
@@ -89,11 +89,21 @@
     (first (sql/query db-conn ["SELECT id, email, full_name, role FROM users WHERE tenant_id = ? AND id = ?" tenant-id user-id])))
 
   (criar-usuario-operador [this tenant-id {:keys [email password full_name]}]
-    (sql/insert! db-conn :users {:tenant_id     tenant-id
-                                 :email         email
-                                 :full_name     full_name
-                                 :password_hash (hashers/encrypt password)
-                                 :role          "operador"}))
+    (jdbc/with-transaction [tx db-conn]
+      (let [tenant (first (sql/query tx ["SELECT operator_limit FROM tenants WHERE id = ?" tenant-id]))
+            operator-limit (:tenants/operator_limit tenant 10) ; Default para 10 se não estiver definido
+            current-operators (count (sql/query tx ["SELECT id FROM users WHERE tenant_id = ?" tenant-id]))]
+        (if (< current-operators operator-limit)
+          (sql/insert! tx :users {:tenant_id     tenant-id
+                                   :email         email
+                                   :full_name     full_name
+                                   :password_hash (hashers/encrypt password)
+                                   :role          "operador"})
+          (throw (ex-info "Limite de operadores atingido para este tenant."
+                          {:type :limite-excedido
+                           :tenant-id tenant-id
+                           :limit operator-limit
+                           :current current-operators}))))))
 
   (atualizar-operador [this tenant-id user-id dados-usuario]
     ;; Apenas o full_name pode ser alterado por enquanto.
@@ -103,7 +113,32 @@
 
   (deletar-operador [this tenant-id user-id]
     ;; Garante que apenas operadores sejam deletados por esta função
-    (sql/delete! db-conn :users {:id user-id :tenant_id tenant-id :role "operador"})))
+    (sql/delete! db-conn :users {:id user-id :tenant_id tenant-id :role "operador"}))
+
+  ;; --- Implementação das Funções de Gestão de Tenants ---
+
+  (listar-tenants [this]
+    (sql/query db-conn ["SELECT id, company_name, subdomain, created_at, operator_limit FROM tenants"]))
+
+  (obter-tenant-por-id [this tenant-id]
+    (first (sql/query db-conn ["SELECT id, company_name, subdomain, created_at, operator_limit FROM tenants WHERE id = ?" tenant-id])))
+
+  (atualizar-tenant [this tenant-id dados-tenant]
+    ;; Apenas company_name e operator_limit podem ser alterados
+    (sql/update! db-conn :tenants
+                 (select-keys dados-tenant [:company_name :operator_limit])
+                 {:id tenant-id}))
+
+  (criar-tenant [this {:keys [company_name subdomain operator_limit]}]
+    (let [subdomain-to-use (or subdomain (-> company_name str/lower-case (str/replace #"[^a-z0-9-]" "-")))]
+      (sql/insert! db-conn :tenants
+                   {:company_name company_name
+                    :subdomain subdomain-to-use
+                    :operator_limit (or operator_limit 10)}
+                   {:return-keys true})))
+
+  (deletar-tenant [this tenant-id]
+    (sql/delete! db-conn :tenants {:id tenant-id})))
 
 ;; --- FUNÇÃO CONSTRUTora ---
 (defn create-repository

--- a/src/juridico/api/db/protocols.clj
+++ b/src/juridico/api/db/protocols.clj
@@ -49,4 +49,21 @@
     "Deleta um usuário operador.")
 
   (obter-operador-por-id [this tenant-id user-id]
-    "Busca um operador específico pelo seu ID."))
+    "Busca um operador específico pelo seu ID.")
+
+  ;; --- Funções de Gestão de Tenants (Super Admin) ---
+
+  (listar-tenants [this]
+    "Retorna uma lista de todos os tenants no sistema.")
+
+  (obter-tenant-por-id [this tenant-id]
+    "Busca um tenant específico pelo seu ID.")
+
+  (atualizar-tenant [this tenant-id dados-tenant]
+    "Atualiza os dados de um tenant específico.")
+
+  (criar-tenant [this dados-tenant]
+    "Cria um novo tenant.")
+
+  (deletar-tenant [this tenant-id]
+    "Deleta um tenant específico."))

--- a/src/juridico/api/handlers.clj
+++ b/src/juridico/api/handlers.clj
@@ -125,10 +125,19 @@
   "Handler para o 'master' criar um novo usuário 'operador' no seu tenant."
   [{:keys [db-repo body-params identity]}]
   (if (s/valid? :juridico.api.specs/create-operator-payload body-params)
-    (let [tenant-id (:tenant-id identity)
-          novo-operador (p/criar-usuario-operador db-repo tenant-id body-params)]
-      {:status 201
-       :body (dissoc novo-operador :password_hash)}) ; Remove o hash da senha da resposta
+    (try
+      (let [tenant-id (:tenant-id identity)
+            novo-operador (p/criar-usuario-operador db-repo tenant-id body-params)]
+        {:status 201
+         :body (dissoc novo-operador :users/password_hash)}) ; Garante que o hash da senha seja removido
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (if (= (:type data) :limite-excedido)
+            {:status 409 ; Conflict
+             :body {:error "Limite de operadores atingido."
+                    :details (str "O limite de " (:limit data) " operadores para este escritório foi atingido.")}}
+            ;; Se for outra exceção, relança
+            (throw e)))))
     {:status 400
      :body {:error "Dados de entrada para criar operador são inválidos."
             :details (s/explain-data :juridico.api.specs/create-operator-payload body-params)}}))
@@ -146,6 +155,26 @@
     {:status 400
      :body {:error "Dados de entrada inválidos."
             :details (s/explain-data :juridico.api.specs/update-operador-payload body-params)}}))
+
+(defn criar-tenant-handler
+  "Handler para o Super Admin criar um novo tenant."
+  [{:keys [db-repo body-params]}]
+  (if (s/valid? :juridico.api.specs/create-tenant-payload body-params)
+    (let [novo-tenant (p/criar-tenant db-repo body-params)]
+      {:status 201
+       :body novo-tenant})
+    {:status 400
+     :body {:error "Dados de entrada inválidos."
+            :details (s/explain-data :juridico.api.specs/create-tenant-payload body-params)}}))
+
+(defn deletar-tenant-handler
+  "Handler para o Super Admin deletar um tenant."
+  [{:keys [db-repo path-params]}]
+  (let [tenant-id (Long/parseLong (:id path-params))
+        linhas-afetadas (p/deletar-tenant db-repo tenant-id)]
+    (if (= 1 (:next.jdbc/update-count linhas-afetadas))
+      {:status 204 :body nil}
+      {:status 404 :body {:error "Tenant não encontrado."}})))
 
 (defn deletar-operador-handler
   "Handler para o 'master' deletar um operador."

--- a/src/juridico/api/middleware.clj
+++ b/src/juridico/api/middleware.clj
@@ -76,3 +76,14 @@
         {:status 403
          :headers {"Content-Type" "application/json"}
          :body "{\"error\": \"Acesso negado. Requer permissão de administrador.\"}"}))))
+
+(defn wrap-super-admin-authorization
+  "Middleware que verifica se o usuário autenticado tem a role 'super-admin'."
+  [handler]
+  (fn [request]
+    (let [role (get-in request [:identity :role])]
+      (if (= role "super-admin")
+        (handler request)
+        {:status 403
+         :headers {"Content-Type" "application/json"}
+         :body "{\"error\": \"Acesso negado. Requer permissão de super administrador.\"}"}))))

--- a/src/juridico/api/specs.clj
+++ b/src/juridico/api/specs.clj
@@ -37,3 +37,8 @@
 (s/def ::create-operator-payload (s/keys :req-un [::email ::password ::full_name]))
 
 (s/def ::update-operador-payload (s/keys :opt-un [::full_name]))
+
+;; --- Specs para Gestão de Tenants (Super Admin) ---
+(s/def ::operator_limit (s/and int? #(> % 0)))
+(s/def ::update-tenant-payload (s/keys :opt-un [::company_name ::operator_limit]))
+(s/def ::create-tenant-payload (s/keys :req-un [::company_name] :opt-un [::subdomain ::operator_limit]))


### PR DESCRIPTION
- Adds a check to limit the number of operators per tenant.
- The `criar-usuario-operador` function now checks the `operator_limit` column in the `tenants` table before creating a new operator.
- The API returns a 409 Conflict error if the limit is reached.

- Adds a full CRUD API for tenant management under the `/admin` prefix.
- The new endpoints are protected by a new `wrap-super-admin-authorization` middleware that checks for the `super-admin` role.
- New functions were added to the `AuthRepository` protocol and implemented in `postgres.clj`.
- New specs were added for the tenant management payloads.

Note: The handlers for `listar-tenants`, `obter-tenant-por-id`, and `atualizar-tenant` are missing from `src/juridico/api/handlers.clj` and will be added in a subsequent commit.