### PR TITLE
feat: Enable CORS for frontend integration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,10 +10,11 @@
                  [metosin/muuntaja "0.6.8"]
                  [buddy/buddy-sign "3.4.333"]
                  [buddy/buddy-hashers "1.8.158"]
-                 [clj-http "3.12.3"]    ; Para fazer a chamada HTTP para API
+                 [clj-http "3.12.3"]
                  [com.github.seancorfield/next.jdbc "1.3.894"]
-                 [org.postgresql/postgresql "42.7.3"]  ; O driver específico do PostgreSQL
-                 [cheshire "5.12.0"]    ; Para converter o payload para JSON
-                 [environ "1.2.0"]]     ; Para ler as credenciais do ambiente
+                 [org.postgresql/postgresql "42.7.3"]
+                 [cheshire "5.12.0"]
+                 [environ "1.2.0"]
+                 [ring-cors "0.1.13"]]
   :main juridico.api.core
   :repl-options {:init-ns juridico.api.core})

--- a/src/juridico/api/core.clj
+++ b/src/juridico/api/core.clj
@@ -4,7 +4,8 @@
             [reitit.ring.middleware.muuntaja :as muuntaja]
             [muuntaja.core :as m]
             [juridico.api.handlers :as h]
-            [juridico.api.middleware :as mw])
+            [juridico.api.middleware :as mw]
+            [ring.middleware.cors :as cors])
   (:gen-class))
 
 ;; --- Rotas da API (Estrutura Corrigida) ---
@@ -81,15 +82,20 @@
       :delete {:handler h/deletar-operador-handler
                :name :operadores/delete}}]]])
 
-;; --- Handler Principal da Aplicação ---
+;; --- Handler Principal da Aplicação (COM A ALTERAÇÃO) ---
 (def app
-  (ring/ring-handler
-   (ring/router
-    routes
-    {:data {:muuntaja m/instance
-            :middleware [muuntaja/format-middleware]}})
-   (ring/create-default-handler
-    {:not-found (constantly {:status 404, :body "{\"error\": \"Rota não encontrada.\"}"})})))
+  (-> (ring/ring-handler
+       (ring/router
+        routes
+        {:data {:muuntaja m/instance
+                :middleware [muuntaja/format-middleware]}})
+       (ring/create-default-handler
+        {:not-found (constantly {:status 404, :body "{\"error\": \"Rota não encontrada.\"}"})}))
+      (cors/wrap-cors
+        :access-control-allow-origin [#".*"]
+        :access-control-allow-methods [:get :post :put :delete]
+        :access-control-allow-headers #{"Content-Type" "Authorization" "X-Tenant-Subdomain"})))
+
 
 ;; --- Ponto de Entrada ---
 (defn -main []


### PR DESCRIPTION
This commit adds Cross-Origin Resource Sharing (CORS) support to the backend API.

- Adds the `ring-cors` library to the project dependencies.
- Wraps the main Ring handler with the `cors/wrap-cors` middleware.
- The configuration allows requests from any origin and explicitly permits the `Authorization` and `X-Tenant-Subdomain` headers, which are necessary for frontend integration.